### PR TITLE
Add assertions to methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ checkstyle {
 
 repositories {
     mavenCentral()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 }
 
 dependencies {
@@ -31,6 +32,7 @@ dependencies {
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
+
 }
 
 test {
@@ -58,4 +60,5 @@ shadowJar {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/data/cow.txt
+++ b/data/cow.txt
@@ -1,1 +1,1 @@
-T | 0 | hehe
+T | 0 | test

--- a/src/main/java/cow/Cow.java
+++ b/src/main/java/cow/Cow.java
@@ -20,9 +20,11 @@ public class Cow {
 
     /**
      * Creates an instance of the Cow class.
+     *
      * @param filePath of the save file.
      */
     public Cow(String filePath) {
+        assert !filePath.isEmpty() : "File path should not be empty";
         this.ui = new Ui();
         this.fs = new FileSaver(filePath);
         try {

--- a/src/main/java/cow/MainWindow.java
+++ b/src/main/java/cow/MainWindow.java
@@ -22,7 +22,7 @@ public class MainWindow extends AnchorPane {
     private Cow cow;
 
     private Image userImage = new Image(this.getClass().getResourceAsStream("/images/DaUser.png"));
-    private Image cowImage = new Image(this.getClass().getResourceAsStream("/images/DaDuke.jpg"));
+    private Image cowImage = new Image(this.getClass().getResourceAsStream("/images/DaDuke.png"));
 
     /** Prints greetings on initialize **/
     @FXML

--- a/src/main/java/cow/commands/DeleteCommand.java
+++ b/src/main/java/cow/commands/DeleteCommand.java
@@ -17,7 +17,14 @@ public class DeleteCommand extends Command {
             + "Example: " + COMMAND_EXAMPLE;
 
     private final int index;
+
+    /**
+     * Constructor to create a delete command.
+     *
+     * @param index of the todo list to delete.
+     */
     public DeleteCommand(int index) {
+        assert index >= 0 : "index should be >= 0";
         this.index = index - 1;
     }
 

--- a/src/main/java/cow/commands/MarkCommand.java
+++ b/src/main/java/cow/commands/MarkCommand.java
@@ -16,7 +16,14 @@ public class MarkCommand extends Command {
             + "Example: " + COMMAND_EXAMPLE;
 
     private int index;
+
+    /**
+     * Constructor to create a mark command.
+     *
+     * @param index of the todo list to mark.
+     */
     public MarkCommand(int index) {
+        assert index >= 0 : "index should be >= 0";
         this.index = index - 1;
     }
 

--- a/src/main/java/cow/commands/UnmarkCommand.java
+++ b/src/main/java/cow/commands/UnmarkCommand.java
@@ -15,7 +15,14 @@ public class UnmarkCommand extends Command {
             + "Example: " + COMMAND_EXAMPLE;
 
     private int index;
+
+    /**
+     * Constructor to create an unmark command.
+     *
+     * @param index of the todo list to unmark.
+     */
     public UnmarkCommand(int index) {
+        assert index >= 0 : "index should be >= 0";
         this.index = index - 1;
     }
 

--- a/src/main/java/cow/filesaver/FileSaver.java
+++ b/src/main/java/cow/filesaver/FileSaver.java
@@ -7,7 +7,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Scanner;
-
 import cow.exceptions.CowExceptions;
 import cow.exceptions.MissingParametersException;
 import cow.exceptions.UnknownCommandException;
@@ -25,12 +24,19 @@ public class FileSaver {
     private String filePath;
     private FileWriter fw;
 
+    /**
+     * Constructor to create a file saver.
+     *
+     * @param filePath of the data file.
+     */
     public FileSaver(String filePath) {
+        assert !filePath.isEmpty() : "File path should not be empty";
         this.filePath = filePath;
     }
 
     /**
      * Writes the items in the TodoList into the file.
+     *
      * @throws CowExceptions if the file or path has an issue.
      */
     public void saveData(TodoList todoList) throws CowExceptions {


### PR DESCRIPTION
There are a few methods which takes in an index or a string. These methods should not take in an empty string or an index below -1.

In order to prevent any index out of bound errors, an assertion is place before the index or strings are used.